### PR TITLE
#12-baseentity-제작

### DIFF
--- a/src/main/java/com/mysettlement/MySettlementApplication.java
+++ b/src/main/java/com/mysettlement/MySettlementApplication.java
@@ -1,14 +1,13 @@
 package com.mysettlement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mysettlement.global.configs.WebSecurityConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@Import(WebSecurityConfig.class)
+@EnableJpaAuditing
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class MySettlementApplication {

--- a/src/main/java/com/mysettlement/domain/user/entity/User.java
+++ b/src/main/java/com/mysettlement/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.mysettlement.domain.user.entity;
 
+import com.mysettlement.global.entity.BaseEntity;
+
 import com.mysettlement.domain.user.dto.request.UserUpdateRequest;
 import com.mysettlement.domain.video.entity.Video;
 import jakarta.persistence.*;
@@ -17,7 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Table(name = "USERS")
 @NoArgsConstructor(access = PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @Column(name = "user_id")

--- a/src/main/java/com/mysettlement/domain/video/entity/Video.java
+++ b/src/main/java/com/mysettlement/domain/video/entity/Video.java
@@ -3,6 +3,7 @@ package com.mysettlement.domain.video.entity;
 import com.mysettlement.domain.user.entity.User;
 import com.mysettlement.domain.video.dto.request.VideoStatusChangeRequest;
 import com.mysettlement.domain.video.dto.request.VideoUpdateRequest;
+import com.mysettlement.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Table(name = "VIDEO")
 @NoArgsConstructor(access = PROTECTED)
-public class Video {
+public class Video extends BaseEntity {
 
     @Id
     @Column(name = "video_id")

--- a/src/main/java/com/mysettlement/global/entity/BaseEntity.java
+++ b/src/main/java/com/mysettlement/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.mysettlement.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
Enable JPA auditing and introduce BaseEntity for shared fields

Added a BaseEntity class with auditing fields `createdAt` and `modifiedAt`, extending it in User and Video entities for code reuse. Enabled JPA auditing in the main application to support automatic timestamp management.